### PR TITLE
Add Click-To-Edit functionality

### DIFF
--- a/OCR/frontend/e2e/ReviewTemplate.spec.ts
+++ b/OCR/frontend/e2e/ReviewTemplate.spec.ts
@@ -30,6 +30,12 @@ test.describe("ReviewTemplate Page", () => {
   test("Submit button navigates correctly", async ({ page }) => {
     const submitButton = page.getByRole("button", { name: "Submit" });
     await expect(submitButton).toBeVisible();
+    await expect(submitButton).toBeDisabled();
+    const errorRows = await page.locator("tr *[data-testid='edit-fix-error']");
+    for (const row of await errorRows.elementHandles()) {
+      await row.click();
+      await page.keyboard.press('Enter');
+    }
 
     await submitButton.click();
     await expect(page).toHaveURL("/extract/submit");
@@ -67,7 +73,7 @@ test.describe("ReviewTemplate Page", () => {
   test("should correctly identify and count errors (below threshold)", async ({
     page,
   }) => {
-    const errorCount = await page.locator("tr .usa-input--error").count();
+    const errorCount = await page.locator("tr .text-error").count();
 
     await expect(errorCount).toBeGreaterThan(0);
   });
@@ -76,6 +82,6 @@ test.describe("ReviewTemplate Page", () => {
     page,
   }) => {
     const DrawLocation = page.locator("td >> text=BH_1Diamondd_LAB");
-    await expect(DrawLocation).toHaveClass(/usa-input--error/);
+    await expect(DrawLocation).toHaveClass(/text-error/);
   });
 });

--- a/OCR/frontend/e2e/ReviewTemplate.spec.ts
+++ b/OCR/frontend/e2e/ReviewTemplate.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 test.describe("ReviewTemplate Page", () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to the ReviewTemplate page
-    await page.goto("http://localhost:5173/extract/review");
+    await page.goto("/extract/review");
   });
 
   test("Document image scrollable", async ({ page }) => {

--- a/OCR/frontend/src/components/EditableText/EditableText.scss
+++ b/OCR/frontend/src/components/EditableText/EditableText.scss
@@ -1,0 +1,19 @@
+.hover-display-icon {
+  svg {
+    opacity: 0;
+    @media (prefers-reduced-motion: no-preference) {
+      transition: opacity 0.2s ease-in-out;
+    }
+  }
+}
+
+.hover-display-icon:hover {
+
+  svg {
+    opacity: 1;
+    @media (prefers-reduced-motion: no-preference) {
+      transition: opacity 0.2s ease-in-out;
+    }
+  }
+}
+

--- a/OCR/frontend/src/components/EditableText/EditableText.tsx
+++ b/OCR/frontend/src/components/EditableText/EditableText.tsx
@@ -1,0 +1,81 @@
+import React, {FC, ReactNode, useEffect, useRef} from 'react';
+import {Icon} from "@trussworks/react-uswds";
+import {useState} from "react";
+
+import './EditableText.scss'
+
+interface EditableTextProps {
+    text: string,
+    onChange: (text: string) => void,
+    onSave: (value: string) => void,
+    onCancel: () => void,
+    onEdit: () => void,
+    isEditing: boolean,
+    isError: boolean,
+    errorMessage: string,
+    onValidate: (text: string) => boolean | string[]
+    textFormatter: (text: string) => ReactNode | string
+}
+
+export const EditableText: FC<EditableTextProps> = ({
+                                                        text, onChange = () => {
+    }, onEdit = () => {
+    }, onSave = () => {
+    }, textFormatter = (text) => text
+                                                    }: EditableTextProps) => {
+    const [isEditing, setIsEditing] = useState(false)
+    const [value, setValue] = useState(text)
+    const inputRef = useRef<HTMLInputElement>(null)
+    useEffect(() => {
+        if (isEditing) {
+            inputRef.current?.focus()
+        }
+    }, [isEditing])
+
+    useEffect(() => {
+        setValue(text)
+    }, [text])
+
+    const _onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setValue(e.target.value)
+        onChange(e.target.value)
+    }
+
+    const _onEdit = () => {
+        setIsEditing(true)
+        // onEdit()
+    }
+
+    const _onSave = () => {
+        setIsEditing(false)
+        onSave(value)
+    }
+
+    const _onCancel = () => {
+        setValue(text)
+        setIsEditing(false)
+    }
+    const _onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            _onSave()
+        }
+        if (e.key === 'Escape') {
+            _onCancel()
+        }
+    }
+
+    return (<>
+        {isEditing ?
+            <input ref={inputRef} className="margin-0 padding-0" type="text" value={value} onChange={_onChange}
+                   onBlur={_onSave} onKeyDown={_onKeyDown}/> :
+            <div className="display-flex flex-align-center hover-display-icon" onClick={_onEdit}>
+                <div className="font-sans-md font-weight-semibold">{textFormatter(value)}</div>
+                <div className="flex-1"></div>
+                <div className="padding-left-1 padding-right-1 custom-tooltip-container display-flex flex-align-end">
+                    <Icon.Edit aria-hidden={true}/>
+                </div>
+            </div>
+        }
+
+    </>)
+}

--- a/OCR/frontend/src/components/EditableText/EditableText.tsx
+++ b/OCR/frontend/src/components/EditableText/EditableText.tsx
@@ -1,6 +1,5 @@
-import React, {FC, ReactNode, useEffect, useRef} from 'react';
-import {Icon} from "@trussworks/react-uswds";
-import {useState} from "react";
+import React, {FC, ReactNode, useEffect, useRef, useState} from 'react';
+import {Icon, TextInput} from "@trussworks/react-uswds";
 
 import './EditableText.scss'
 
@@ -15,17 +14,20 @@ interface EditableTextProps {
     errorMessage: string,
     onValidate: (text: string) => boolean | string[]
     textFormatter: (text: string) => ReactNode | string
+    dataTestId?: string
 }
 
 export const EditableText: FC<EditableTextProps> = ({
-                                                        text, onChange = () => {
-    }, onEdit = () => {
-    }, onSave = () => {
-    }, textFormatter = (text) => text
+                                                        text, dataTestId,
+                                                        onChange = () => {
+                                                        },
+                                                        onSave = () => {
+                                                        },
+                                                        textFormatter = (text) => text
                                                     }: EditableTextProps) => {
     const [isEditing, setIsEditing] = useState(false)
     const [value, setValue] = useState(text)
-    const inputRef = useRef<HTMLInputElement>(null)
+    const inputRef = useRef<HTMLInputElement | null>(null)
     useEffect(() => {
         if (isEditing) {
             inputRef.current?.focus()
@@ -66,16 +68,16 @@ export const EditableText: FC<EditableTextProps> = ({
 
     return (<>
         {isEditing ?
-            <input ref={inputRef} className="margin-0 padding-0" type="text" value={value} onChange={_onChange}
-                   onBlur={_onSave} onKeyDown={_onKeyDown}/> :
-            <div className="display-flex flex-align-center hover-display-icon" onClick={_onEdit}>
+            <TextInput inputRef={inputRef} className="margin-0 padding-0" type="text" value={value} onChange={_onChange}
+                       onBlur={_onSave} onKeyDown={_onKeyDown} id={value}/> :
+            <div data-testid={dataTestId} className="display-flex flex-align-center hover-display-icon"
+                 onClick={_onEdit}>
                 <div className="font-sans-md font-weight-semibold">{textFormatter(value)}</div>
                 <div className="flex-1"></div>
                 <div className="padding-left-1 padding-right-1 custom-tooltip-container display-flex flex-align-end">
                     <Icon.Edit aria-hidden={true}/>
                 </div>
-            </div>
-        }
+            </div>}
 
     </>)
 }

--- a/OCR/frontend/src/components/SortableTable/SortableTable.tsx
+++ b/OCR/frontend/src/components/SortableTable/SortableTable.tsx
@@ -11,7 +11,7 @@ interface SortableTableProps {
     defaultDescending: boolean | undefined,
     columns: Array<string> | undefined,
     columnNames: Map<string, string> | undefined,
-    formatters: Map<string, (any) => object> | undefined
+    formatters: Map<string, (any, number, any ) => object> | undefined
 }
 
 const SORTS = {
@@ -70,7 +70,7 @@ export const SortableTable: FC<SortableTableProps> = ({
                     return (<tr key={idx}>
                         {columns?.map((col, colIdx) => {
                             return <td
-                                key={colIdx}>{formatters?.[col] ? formatters?.[col](t[col]) : t[col]?.toString()}</td>
+                                key={colIdx}>{formatters?.[col] ? formatters?.[col](t[col], colIdx, t) : t[col]?.toString()}</td>
                         })}
                     </tr>)
                 })}

--- a/OCR/frontend/src/components/SortableTable/SortableTable.tsx
+++ b/OCR/frontend/src/components/SortableTable/SortableTable.tsx
@@ -70,7 +70,7 @@ export const SortableTable: FC<SortableTableProps> = ({
                     return (<tr key={idx}>
                         {columns?.map((col, colIdx) => {
                             return <td
-                                key={colIdx}>{formatters?.[col] ? formatters?.[col](t[col], colIdx, t) : t[col]?.toString()}</td>
+                                key={colIdx}>{formatters?.[col] ? formatters?.[col](t[col], idx, t) : t[col]?.toString()}</td>
                         })}
                     </tr>)
                 })}

--- a/OCR/frontend/src/pages/ReviewTemplate.tsx
+++ b/OCR/frontend/src/pages/ReviewTemplate.tsx
@@ -9,6 +9,7 @@ import { Divider } from "../components/Divider";
 import documentImage from "./SyphForm.png"; //Please enter your file of choice here
 import "./ReviewTemplate.scss";
 import aiIconUrl from "../assets/ai_icon.svg";
+import {SortableTable} from "../components/SortableTable/SortableTable.tsx";
 
 interface Result {
   text: string;
@@ -94,6 +95,26 @@ const ReviewTemplate: React.FC = () => {
   const hasErrors = errorCount > 0;
   const overallConfidence = calculateOverallConfidence();
 
+  const resultsTable = Object.entries(results).map(([k, v], idx) => {
+    return {
+      index: idx,
+      name: k,
+      value: v.text,
+      confidence: v.confidence,
+      isError: v.confidence <= confidenceVal,
+      isEdited: false,
+      isEditing: false
+    }
+  });
+
+  const isErrorFormatter = (d) => {
+    return d ? <Icon.Warning className="text-error" /> : "";
+  }
+
+  const redTextOnErrorFormatter = (d, _idx, row) => {
+    return row.isError ? <span className="usa-input--error">{d}</span> : d;
+  }
+
   return (
     <div className="display-flex flex-column flex-justify-start width-full height-full padding-1 padding-top-2">
       <ExtractDataHeader
@@ -151,35 +172,14 @@ const ReviewTemplate: React.FC = () => {
             </div>
           </div>
 
-          <Table fullWidth striped>
-            <thead>
-              <tr>
-                <th>Label</th>
-                <th>Value</th>
-                <th></th>
-                <th>Label Confidence</th>
-              </tr>
-            </thead>
-            <tbody>
-              {Object.entries(results).map(([key, value]) => {
-                const isError = value.confidence <= confidenceVal;
-                return (
-                  <tr key={key}>
-                    <td>{key}</td>
-                    <td className={`${isError ? "usa-input--error" : ""}`}>
-                      {value.text}
-                    </td>
-                    <td>
-                      {isError && <Icon.Warning className="text-error" />}
-                    </td>
-                    <td className={`${isError ? "usa-input--error" : ""}`}>
-                      {`${value.confidence}%`}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </Table>
+          <SortableTable
+              columns={["name", "value", "isError", "confidence"]}
+              data={resultsTable}
+              sortableBy={["name", "confidence", "value"]}
+              columnNames={{name: "Label", value: "Value", isError: " ", confidence: "Label Confidence"}}
+              formatters={{isError: isErrorFormatter, confidence: redTextOnErrorFormatter, value: redTextOnErrorFormatter}}
+            />
+
         </div>
         <div className="width-50">
           <div

--- a/OCR/frontend/src/pages/ReviewTemplate.tsx
+++ b/OCR/frontend/src/pages/ReviewTemplate.tsx
@@ -124,14 +124,13 @@ const ReviewTemplate: React.FC = () => {
   }
 
   const redTextOnErrorFormatter = (d, _idx, row) => {
-    return row.isError ? <span className="text-red">{d}</span> : d;
+    return row.isError ? <span className="text-error">{d}</span> : d;
   }
 
   const editCellFormatter = (d, _idx, row) => {
-    return <EditableText text={d} onSave={(value) => {
-
+    return <EditableText dataTestId={`${row.isError ? 'edit-fix-error' : null}`} text={d} onSave={(value) => {
       setEditedValues({...editedValues, [row.name]: value})
-    }} textFormatter={(s) => row.isError ? <span className="text-red">{s}</span> : s}/>
+    }} textFormatter={(s) => row.isError ? <span className="text-error">{s}</span> : s}/>
   }
 
   return (

--- a/OCR/frontend/src/style/index.scss
+++ b/OCR/frontend/src/style/index.scss
@@ -2,8 +2,9 @@
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
+  height: 100%;
+  width: 100%;
 
-  color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
 
@@ -11,4 +12,9 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  height: 100vh;
+  width: 100vw;
 }

--- a/OCR/frontend/tsconfig.app.json
+++ b/OCR/frontend/tsconfig.app.json
@@ -21,7 +21,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
- Adds the click to edit functions for the review and edit page
  - Return will commit changes
  - Escape will revert changes since last commit
  - Clicking outside of the text box will commit changes

- If there are errors Submit button on review page will be disabled

- Hovering over content will display icon (transition of icon will respect
reduce motion preferences)

- Minor tsconfig tweak to remove error when importing
syntheticDefaultImports

- Use SortableTable on Review page
- Update SortableTable to pass formatter function (value, idx, row) to allow more complex formatting
- Fix bug with Sortable Table passing in wrong index to formatter
functions

Demo: 
![Kapture 2024-09-25 at 15 14 31](https://github.com/user-attachments/assets/0f66207a-d790-4fa2-9380-3490dd633947)

