### PR TITLE
update app gateway with separate network and add WAF protections

### DIFF
--- a/ops/terraform/locals.tf
+++ b/ops/terraform/locals.tf
@@ -14,6 +14,7 @@ locals {
       websubnetcidr        = "10.0.3.0/24"
       lbsubnetcidr         = "10.0.4.0/24"
       dbsubnetcidr         = "10.0.5.0/24"
+      appgwsubnetcidr      = "10.0.6.0/24"
     }
   }
   demo = {
@@ -24,6 +25,7 @@ locals {
       websubnetcidr        = "10.1.3.0/24"
       lbsubnetcidr         = "10.1.4.0/24"
       dbsubnetcidr         = "10.1.5.0/24"
+      appgwsubnetcidr      = "10.1.6.0/24"
     }
   }
 }

--- a/ops/terraform/main.tf
+++ b/ops/terraform/main.tf
@@ -19,6 +19,7 @@ module "networking" {
   ocrsubnetcidr        = local.workspace["ocrsubnetcidr"]
   middlewaresubnetcidr = local.workspace["middlewaresubnetcidr"]
   dbsubnetcidr         = local.workspace["dbsubnetcidr"]
+  appgwsubnetcidr      = local.workspace["appgwsubnetcidr"]
   env                  = local.environment
 
   # The DNS zone and DNS link are managed inside the networking module.
@@ -43,10 +44,10 @@ module "app_gateway" {
   resource_group_location = data.azurerm_resource_group.rg.location
   resource_group_name     = data.azurerm_resource_group.rg.name
 
-  blob_endpoint = module.storage.primary_web_host
-  lb_subnet     = module.networking.lbsubnet_id
-  tags          = local.management_tags
-  env           = local.environment
+  blob_endpoint   = module.storage.primary_web_host
+  appgw_subnet_id = module.networking.appgwsubnet_id
+  tags            = local.management_tags
+  env             = local.environment
 
   fqdns_ocr        = module.ocr_api.app_hostname
   fqdns_middleware = module.middleware_api.app_hostname

--- a/ops/terraform/modules/app_gateway/main.tf
+++ b/ops/terraform/modules/app_gateway/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_application_gateway" "load_balancer" {
 
   sku {
     name = "WAF_v2"
-    tier = "WAF_v2" # WAF tier depreciated, set to WAF_v2 tier
+    tier = "WAF_v2" # WAF tier depreciated, set to WAF_v2 tier 
     # capacity = 2
   }
 
@@ -48,7 +48,6 @@ resource "azurerm_application_gateway" "load_balancer" {
     min_capacity = 2
     max_capacity = 5
   }
-
 
   # Enable Web Application Firewall
   waf_configuration {
@@ -59,8 +58,8 @@ resource "azurerm_application_gateway" "load_balancer" {
   }
 
   gateway_ip_configuration {
-    name      = "${var.name}-gateway-ip-configuration"
-    subnet_id = var.lb_subnet
+    name      = "${var.name}-gateway-ip-configuration-${var.env}"
+    subnet_id = var.appgw_subnet_id
   }
 
   # ------- Static -------------------------

--- a/ops/terraform/modules/app_gateway/main.tf
+++ b/ops/terraform/modules/app_gateway/main.tf
@@ -39,8 +39,23 @@ resource "azurerm_application_gateway" "load_balancer" {
   location            = var.resource_group_location
 
   sku {
-    name     = "Standard_v2"
-    tier     = "Standard_v2"
+    name = "WAF_v2"
+    tier = "WAF_v2" # WAF tier depreciated, set to WAF_v2 tier
+    # capacity = 2
+  }
+
+  autoscale_configuration {
+    min_capacity = 2
+    max_capacity = 5
+  }
+
+
+  # Enable Web Application Firewall
+  waf_configuration {
+    enabled          = true
+    firewall_mode    = "Prevention" # to block malicious traffic
+    rule_set_type    = "OWASP"
+    rule_set_version = "3.2"
   }
 
   gateway_ip_configuration {
@@ -271,10 +286,5 @@ resource "azurerm_application_gateway" "load_balancer" {
         query_string = "{var_query_string}"
       }
     }
-  }
-
-  autoscale_configuration {
-    min_capacity = 0
-    max_capacity = 5
   }
 }

--- a/ops/terraform/modules/app_gateway/variables.tf
+++ b/ops/terraform/modules/app_gateway/variables.tf
@@ -1,7 +1,8 @@
 variable "name" {}
 variable "resource_group_name" {}
 variable "resource_group_location" {}
-variable "lb_subnet" {}
+variable "appgw_subnet_id" {}
+# variable "lb_subnet" {}
 variable "blob_endpoint" {}
 variable "tags" {}
 

--- a/ops/terraform/modules/app_gateway/variables.tf
+++ b/ops/terraform/modules/app_gateway/variables.tf
@@ -2,7 +2,6 @@ variable "name" {}
 variable "resource_group_name" {}
 variable "resource_group_location" {}
 variable "appgw_subnet_id" {}
-# variable "lb_subnet" {}
 variable "blob_endpoint" {}
 variable "tags" {}
 

--- a/ops/terraform/modules/network/main.tf
+++ b/ops/terraform/modules/network/main.tf
@@ -15,6 +15,7 @@ resource "azurerm_subnet" "appgw_subnet" {
     "Microsoft.Storage",
   ]
 }
+
 resource "azurerm_subnet" "web-subnet" {
   name                 = "${var.name}-web-subnet-${var.env}"
   virtual_network_name = azurerm_virtual_network.vnet.name

--- a/ops/terraform/modules/network/main.tf
+++ b/ops/terraform/modules/network/main.tf
@@ -5,6 +5,16 @@ resource "azurerm_virtual_network" "vnet" {
   address_space       = [var.vnetcidr]
 }
 
+resource "azurerm_subnet" "appgw_subnet" {
+  name                 = "${var.name}-appgw-subnet-${var.env}"
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = var.resource_group
+  address_prefixes     = [var.appgwsubnetcidr]
+  service_endpoints = [
+    "Microsoft.Sql",
+    "Microsoft.Storage",
+  ]
+}
 resource "azurerm_subnet" "web-subnet" {
   name                 = "${var.name}-web-subnet-${var.env}"
   virtual_network_name = azurerm_virtual_network.vnet.name

--- a/ops/terraform/modules/network/outputs.tf
+++ b/ops/terraform/modules/network/outputs.tf
@@ -8,6 +8,11 @@ output "websubnet_id" {
   description = "Id of websubnet in the network"
 }
 
+output "appgwsubnet_id" {
+  value       = azurerm_subnet.appgw_subnet.id
+  description = "ID of the appgwsubnet in the network"
+}
+
 output "dbsubnet_id" {
   value       = azurerm_subnet.db-subnet.id
   description = "Id of dbsubnet in the network"

--- a/ops/terraform/modules/network/variables.tf
+++ b/ops/terraform/modules/network/variables.tf
@@ -7,6 +7,7 @@ variable "ocrsubnetcidr" {}
 variable "env" {}
 variable "middlewaresubnetcidr" {}
 variable "dbsubnetcidr" {}
+variable "appgwsubnetcidr" {}
 
 variable "location" {
   default = "eastus2"


### PR DESCRIPTION
## Description
Updated appgw with its own independent subnet and added Web Application Firewall (WAF) protections to provide added security for our end users and Azure resources.  The separate subnet resolved the error shown below.  This error resulted when we were using the load balancer subnet in our gateway configurations, causing conflicts when trying to deploy the appgw via terraform.

```
Error: creating Application Gateway (Subscription: "72d4d159-ba2c-4fee-82da-4ff96e9195cb"
│ Resource Group Name: "reportvision-rg-dev"
│ Application Gateway Name: "reportvision-appgateway-dev"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: ApplicationGatewaySubnetCannotHaveOtherResources: Subnet /subscriptions/72d4d159-ba2c-4fee-82da-4ff96e9195cb/resourceGroups/reportvision-rg-dev/providers/Microsoft.Network/virtualNetworks/reportvision-vnet-dev/subnets/reportvision-lb-subnet-dev cannot be used for application gateway /subscriptions/72d4d159-ba2c-4fee-82da-4ff96e9195cb/resourceGroups/reportvision-rg-dev/providers/Microsoft.Network/applicationGateways/reportvision-appgateway-dev since it has other resources deployed. Subnet used for application gateway can only have other application gateways.
│ 
│   with module.app_gateway.azurerm_application_gateway.load_balancer,
│   on modules/app_gateway/main.tf line 36, in resource "azurerm_application_gateway" "load_balancer":
│   36: resource "azurerm_application_gateway" "load_balancer" {

```

## Related Issues
#463 

## Checklist
- [ x ] The title of this PR is descriptive and concise.
- [ x ] My changes follow the style guidelines of this project.
- [ x ] Terraform code has been tested.
- [ x ] I've let the team know about this PR by linking it in the review channel


